### PR TITLE
Move the override one step lower.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+2.8.0
+-----
+
+* [Replace deprecated fragment_cache_key for Rails 5.2 support](https://github.com/rails/jbuilder/pull/430)
+
+2.7.0
+-----
+
+* [Requires Rails 4+](https://github.com/rails/jbuilder/commit/5207ff394533177fffdd768bfaa6413a0cd16dc8)
+* [Fix implicitly rendering a JSON partial with the same name as an
+   HTML partial](https://github.com/rails/jbuilder/pull/400)
+
 2.6.4
 -----
 

--- a/jbuilder.gemspec
+++ b/jbuilder.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name     = 'jbuilder'
-  s.version  = '2.7.0'
+  s.version  = '2.8.0'
   s.authors  = 'David Heinemeier Hansson'
   s.email    = 'david@basecamp.com'
   s.summary  = 'Create JSON structures via a Builder-style DSL'

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -104,7 +104,7 @@ class JbuilderTemplate < Jbuilder
   private
 
   def _render_partial_with_options(options)
-    options.reverse_merge! locals: {}
+    options.reverse_merge! locals: options.except(:partial, :as, :collection)
     options.reverse_merge! ::JbuilderTemplate.template_lookup_options
     as = options[:as]
 
@@ -199,7 +199,6 @@ class JbuilderTemplate < Jbuilder
     when ::Hash
       # partial! partial: 'name', foo: 'bar'
       options = name_or_options
-      options[:locals] ||= options.except(:partial, :as, :collection)
     else
       # partial! 'name', locals: {foo: 'bar'}
       if locals.one? && (locals.keys.first == :locals)


### PR DESCRIPTION
The previous location relied on calling `_render_partial_with_options`
but there was another case where we call
```
json.bars foo.bars, partial: 'bars', as: :bar, include_baz: true
```
where, because there were args to the partial, we end up hitting
`_set_inline_partial` which did not route through
`_render_explicit_partial`. Putting it in a common location allows it to
work for both.